### PR TITLE
fix:SassC::SyntaxErrorでtop.html.erb修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,6 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
-.header-background {
-  background-color: rgb(137, 170, 211);
+@layer components {
+  .header-background {
+    background-color: rgb(137, 170, 211);
+  }
+
+  .text-navy {
+    color: rgb(7, 52, 114);
+  }
+
+  .text-pink {
+    color: rgb(221, 117, 148);
+  }
 }

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -3,14 +3,13 @@
     <div class="mb-8">
       <%= image_tag "346b73ecd76ad3608a6b67470d7b86dd.jpg", alt: "桜の風景", class: "w-full rounded-lg shadow-lg" %>
     </div>
-    <h2 class="text-[#073472] text-2xl font-semibold mb-4">
-  思い出の<span class="text-[#DD7594]">桜</span>写真で大切な人に<span class="text-[#DD7594]">感謝</span>を伝えよう
+    <h2 class="text-navy text-2xl font-semibold mb-4">
+      思い出の<span class="text-pink">桜</span>写真で大切な人に<span class="text-pink">感謝</span>を伝えよう
     </h2>
     <!-- アプリの使い方ボタンを追加 -->
     <div class="mb-8">
       <%= link_to "アプリの使い方", "#", class: "btn text-white border-none hover:opacity-80", style: "background-color: #4981CF;" %>
     </div>
-  </div>
 
     <div class="flex justify-center gap-8 mt-8">
       <%= link_to "投稿を見る", "#", class: "btn text-white border-none hover:opacity-80", style: "background-color: #DD7594;" %>


### PR DESCRIPTION
- 直接の16進数カラーコード指定（text-[#073472]）を避け、カスタムクラスを使用
- rgbの値を正しい形式で指定（カンマ区切り）

- カスタムクラスを@layer components内に定義して適切なスコープを設定