### PR TITLE
fix:SassC::SyntaxError解消のためrgb関数をrgba関数に変更

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -4,14 +4,14 @@
 
 @layer components {
   .header-background {
-    background-color: rgb(137, 170, 211);
+    background-color: rgba(137, 170, 211, 1);
   }
 
   .text-navy {
-    color: rgb(7, 52, 114);
+    color: rgba(7, 52, 114, 1);
   }
 
   .text-pink {
-    color: rgb(221, 117, 148);
+    color: rgba(221, 117, 148, 1);
   }
 }

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,11 +1,11 @@
-<footer class="header-background py-4">
+<footer style="background-color: rgba(137, 170, 211, 1)" class="py-4">
   <div class="container mx-auto px-4">
     <div class="flex justify-center space-x-8">
-      <%= link_to "プライバシーポリシー", "#", class: "text-white hover:opacity-80" %>
-      <%= link_to "利用規約", "#", class: "text-white hover:opacity-80" %>
-      <%= link_to "お問い合わせ", "#", class: "text-white hover:opacity-80" %>
+      <%= link_to "プライバシーポリシー", "#", class: "text-[#FFFFFF] hover:opacity-80" %>
+      <%= link_to "利用規約", "#", class: "text-[#FFFFFF] hover:opacity-80" %>
+      <%= link_to "お問い合わせ", "#", class: "text-[#FFFFFF] hover:opacity-80" %>
     </div>
-    <div class="text-center text-white mt-4">
+    <div class="text-center text-[#FFFFFF] mt-4">
       <p>© <%= Time.current.year %> Sakura Thanks - All rights reserved</p>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,15 +1,15 @@
-<header class="header-background">
+<header style="background-color: rgba(137, 170, 211, 1)">
   <div class="container mx-auto px-4">
     <div class="navbar min-h-16">
       <div class="flex-1">
-        <%= link_to root_path, class: "text-white text-xl font-semibold" do %>
+        <%= link_to root_path, class: "text-[#FFFFFF] text-xl font-semibold" do %>
           Sakura Thanks
         <% end %>
       </div>
       <div class="flex-none gap-4">
-        <%= link_to "一覧ページ", "#", class: "text-white hover:opacity-80" %>
-        <%= link_to "ログイン", "#", class: "text-white hover:opacity-80" %>
-        <%= link_to "新規登録", "#", class: "text-white hover:opacity-80" %>
+        <%= link_to "一覧ページ", "#", class: "text-[#FFFFFF] hover:opacity-80" %>
+        <%= link_to "ログイン", "#", class: "text-[#FFFFFF] hover:opacity-80" %>
+        <%= link_to "新規登録", "#", class: "text-[#FFFFFF] hover:opacity-80" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
rgb関数をrgba関数に変更
text-whiteクラスをtext-[#FFFFFF]に変更
透明度を明示的に指定（1）