### PR TITLE
fix:SassC::SyntaxError text-whiteクラスをtext-[#FFFFFF]に変更

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -14,4 +14,8 @@
   .text-pink {
     color: rgba(221, 117, 148, 1);
   }
+
+  .custom-text-white {
+    color: rgba(255, 255, 255, 1);
+  }
 }

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -8,12 +8,12 @@
     </h2>
     <!-- アプリの使い方ボタンを追加 -->
     <div class="mb-8">
-      <%= link_to "アプリの使い方", "#", class: "btn text-white border-none hover:opacity-80", style: "background-color: #4981CF;" %>
+      <%= link_to "アプリの使い方", "#", class: "btn text-[#FFFFFF] border-none hover:opacity-80", style: "background-color: #4981CF;" %>
     </div>
-
+    
     <div class="flex justify-center gap-8 mt-8">
-      <%= link_to "投稿を見る", "#", class: "btn text-white border-none hover:opacity-80", style: "background-color: #DD7594;" %>
-      <%= link_to "投稿する", "#", class: "btn text-white border-none hover:opacity-80", style: "background-color: #DD7594;" %>
+      <%= link_to "投稿を見る", "#", class: "btn text-[#FFFFFF] border-none hover:opacity-80", style: "background-color: #DD7594;" %>
+      <%= link_to "投稿する", "#", class: "btn text-[#FFFFFF] border-none hover:opacity-80", style: "background-color: #DD7594;" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
text-whiteクラスをtext-[#FFFFFF]に変更

TailwindCSSの直接的なカラーコード指定を使用
SassのRGB関数の問題を回避