### PR TITLE
fix:SassC::SyntaxError解消のためrgbやrgbaを使わず、直接HEXカラーコードを使用

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -15,7 +15,8 @@
     color: rgba(221, 117, 148, 1);
   }
 
-  .custom-text-white {
-    color: rgba(255, 255, 255, 1);
+  /* 白文字用のカスタムクラス */
+  .btn-text {
+    color: #FFFFFF;
   }
 }

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -8,12 +8,12 @@
     </h2>
     <!-- アプリの使い方ボタンを追加 -->
     <div class="mb-8">
-      <%= link_to "アプリの使い方", "#", class: "btn text-[#FFFFFF] border-none hover:opacity-80", style: "background-color: #4981CF;" %>
+    <%= link_to "アプリの使い方", "#", class: "btn btn-text border-none hover:opacity-80", style: "background-color: #4981CF;" %>
     </div>
-    
+  
     <div class="flex justify-center gap-8 mt-8">
-      <%= link_to "投稿を見る", "#", class: "btn text-[#FFFFFF] border-none hover:opacity-80", style: "background-color: #DD7594;" %>
-      <%= link_to "投稿する", "#", class: "btn text-[#FFFFFF] border-none hover:opacity-80", style: "background-color: #DD7594;" %>
-    </div>
+    <%= link_to "投稿を見る", "#", class: "btn btn-text border-none hover:opacity-80", style: "background-color: #DD7594;" %>
+    <%= link_to "投稿する", "#", class: "btn btn-text border-none hover:opacity-80", style: "background-color: #DD7594;" %>
+  </div>
   </div>
 </div>


### PR DESCRIPTION
rgbやrgbaを使わず、直接HEXカラーコードを使用
文字色用に専用のクラス(btn-text)を作成
Tailwindのビルトインクラスを避け、カスタムクラスを使用