### PR TITLE
fix:SassC::SyntaxError Tailwindのユーティリティレイヤーでボタンのスタイルを再定義

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .btn {
+    @apply text-[#FFFFFF];
+  }
+}
+
 @layer components {
   .header-background {
     background-color: rgba(137, 170, 211, 1);
@@ -13,10 +19,5 @@
 
   .text-pink {
     color: rgba(221, 117, 148, 1);
-  }
-
-  /* 白文字用のカスタムクラス */
-  .btn-text {
-    color: #FFFFFF;
   }
 }

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -8,12 +8,12 @@
     </h2>
     <!-- アプリの使い方ボタンを追加 -->
     <div class="mb-8">
-    <%= link_to "アプリの使い方", "#", class: "btn btn-text border-none hover:opacity-80", style: "background-color: #4981CF;" %>
+    <%= link_to "アプリの使い方", "#", class: "btn border-none hover:opacity-80", style: "background-color: #4981CF;" %>
     </div>
   
     <div class="flex justify-center gap-8 mt-8">
-    <%= link_to "投稿を見る", "#", class: "btn btn-text border-none hover:opacity-80", style: "background-color: #DD7594;" %>
-    <%= link_to "投稿する", "#", class: "btn btn-text border-none hover:opacity-80", style: "background-color: #DD7594;" %>
+    <%= link_to "投稿を見る", "#", class: "btn border-none hover:opacity-80", style: "background-color: #DD7594;" %>
+    <%= link_to "投稿する", "#", class: "btn border-none hover:opacity-80", style: "background-color: #DD7594;" %>
   </div>
   </div>
 </div>


### PR DESCRIPTION
rgbやrgba関数の使用を完全に避ける
Tailwindのユーティリティレイヤーでボタンのスタイルを再定義
HEXカラーコードを直接指定することでSassの解釈エラーを回避