### PR TITLE
fix:SassC::SyntaxError解消のためRGB表記を完全に避け、HEX値に統一

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,7 +11,7 @@ module.exports = {
         'inter': ['Inter', 'sans-serif'],
       },
       colors: {
-        'header-footer': 'rgb(137, 170, 211)',
+        'header-footer': '#89AAD3', // rgbから16進数に変更
         'main-text': '#073472',
         'accent': '#DD7594',
         'button-blue': '#4981CF',


### PR DESCRIPTION
RGB表記を完全に避け、HEX値に統一
node_modulesの再インストール
ビルドファイルの完全クリーンアップ