### PR TITLE
掲示板の画像アップロード機能（モデルとDB設定）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-
 source "https://rubygems.org"
 ruby "3.3.6"
 
@@ -36,7 +35,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,11 +111,22 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-aarch64-linux-musl)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm-linux-musl)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.1-x86_64-linux-musl)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.0)
     irb (1.14.3)
       rdoc (>= 4.0.0)
@@ -140,6 +151,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
@@ -269,6 +281,9 @@ GEM
       rubocop-performance
       rubocop-rails
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.27.0)
@@ -338,6 +353,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
   mysql2 (~> 0.5)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,8 +6,8 @@ class Post < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_one_attached :image  # Active Storageの関連付けを追加
 
-  validates :title, presence: { message: 'を入力してください' }
-  validates :content, presence: { message: 'を入力してください' }
+  validates :title, presence: { message: "を入力してください" }
+  validates :content, presence: { message: "を入力してください" }
   # 画像の検証
   validate :acceptable_image, if: :image_attached?
 
@@ -22,16 +22,16 @@ class Post < ApplicationRecord
   def acceptable_image
     # ファイルサイズの検証（5MB以下）
     if image.blob.byte_size > 5.megabytes
-      errors.add(:image, 'は5MB以下にしてください')
+      errors.add(:image, "は5MB以下にしてください")
     end
 
     # ファイル形式の検証（jpg, jpeg, png, gifのみ許可）
-    acceptable_types = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif']
+    acceptable_types = [ "image/jpeg", "image/jpg", "image/png", "image/gif" ]
     unless acceptable_types.include?(image.content_type)
-      errors.add(:image, 'はJPG、JPEG、PNG、GIF形式でアップロードしてください')
+      errors.add(:image, "はJPG、JPEG、PNG、GIF形式でアップロードしてください")
     end
-  rescue 
+  rescue
     # 画像の検証中にエラーが発生した場合
-    errors.add(:image, 'を処理できませんでした。ファイルを確認してください')
+    errors.add(:image, "を処理できませんでした。ファイルを確認してください")
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,8 @@ class Post < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_one_attached :image  # Active Storageの関連付けを追加
 
+  validates :title, presence: { message: 'を入力してください' }
+  validates :content, presence: { message: 'を入力してください' }
   # 画像の検証
   validate :acceptable_image, if: :image_attached?
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,35 @@
+# app/models/post.rb
 class Post < ApplicationRecord
+  # 関連付け
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :favorites, dependent: :destroy
+  has_one_attached :image  # Active Storageの関連付けを追加
+
+  # 画像の検証
+  validate :acceptable_image, if: :image_attached?
+
+  private
+
+  # 画像が添付されているかをチェック
+  def image_attached?
+    image.attached?
+  end
+
+  # 画像のバリデーションロジック
+  def acceptable_image
+    # ファイルサイズの検証（5MB以下）
+    if image.blob.byte_size > 5.megabytes
+      errors.add(:image, 'は5MB以下にしてください')
+    end
+
+    # ファイル形式の検証（jpg, jpeg, png, gifのみ許可）
+    acceptable_types = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif']
+    unless acceptable_types.include?(image.content_type)
+      errors.add(:image, 'はJPG、JPEG、PNG、GIF形式でアップロードしてください')
+    end
+  rescue 
+    # 画像の検証中にエラーが発生した場合
+    errors.add(:image, 'を処理できませんでした。ファイルを確認してください')
+  end
 end

--- a/db/migrate/20250123114648_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250123114648_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_21_094126) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_23_114648) do
+  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"
     t.text "content"
@@ -37,5 +65,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_21_094126) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
-  image-processing gem追加しインストール
-  Active Storageをインストールしマイグレーション
-  アップロードできるファイルを jpg, jpeg, png, gifのみに指定
- imageカラムに値が無い場合は、デフォルトの別画像表示のモデル作成