### PR TITLE
add:投稿詳細機能実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  skip_before_action :require_login, only: %i[index]
+  skip_before_action :require_login, only: %i[index show]
   def index
     @posts = Post.includes(:user).order(created_at: :desc)
   end
@@ -16,6 +16,10 @@ def create
   else
     render :new, status: :unprocessable_entity
   end
+end
+
+def show
+  @post = Post.find(params[:id])
 end
 
 private

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,17 +2,19 @@
   <div class="bg-white rounded-lg shadow-lg h-32">
     <div class="flex h-full p-4">
       <div class="w-1/4 pr-4">
-        <% if post.image.attached? %>
-          <%= image_tag post.image, class: "w-full h-full object-cover rounded-lg" %>
-        <% else %>
-          <%= image_tag "Cropped_Image copy.png", class: "w-full h-full object-cover rounded-lg" %>
+        <%= link_to post_path(post), class: "hover:opacity-80" do %>
+          <% if post.image.attached? %>
+            <%= image_tag post.image, class: "w-full h-full object-cover rounded-lg" %>
+          <% else %>
+            <%= image_tag "Cropped_Image copy.png", class: "w-full h-full object-cover rounded-lg" %>
+          <% end %>
         <% end %>
       </div>
 
       <div class="flex-1 flex flex-col justify-between">
         <div class="text-center">
           <h2 class="text-lg font-bold" style="color: #000000;">
-            <%= post.title %>
+            <%= link_to post.title, post_path(post), class: "hover:opacity-50" %>
           </h2>
           <p class="mt-1 text-sm" style="color: #000000;">
             <%= truncate(post.content, length: 50) %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,33 @@
+<div class="min-h-screen bg-base-100">
+  <div class="container mx-auto px-4 py-8">
+    <h1 class="text-2xl font-bold text-center mb-8" style="color: #073472;">投稿詳細</h1>
+    
+    <div class="max-w-4xl mx-auto space-y-4"> <%# space-y-4 を追加 %>
+      <%# 画像部分 %>
+      <div class="bg-white rounded-lg shadow-lg overflow-hidden">
+        <% if @post.image.attached? %>
+          <%= image_tag @post.image, class: "w-full h-64 object-cover" %>
+        <% else %>
+          <%= image_tag "Cropped_Image copy.png", class: "w-full h-64 object-cover" %>
+        <% end %>
+      </div>
+
+      <%# コンテンツ部分 %>
+      <div class="bg-white rounded-lg shadow-lg overflow-hidden">
+        <div class="p-6">
+          <h2 class="text-xl font-bold mb-4" style="color: #000000;">
+            <%= @post.title %>
+          </h2>
+          
+          <p class="mb-4" style="color: #000000;">
+            <%= @post.content %>
+          </p>
+          
+          <p class="text-sm" style="color: #000000;">
+            投稿者: <%= @post.user.name %>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,14 +2,14 @@
   <div class="container mx-auto px-4">
     <div class="navbar min-h-16">
       <div class="flex-1">
-        <%= link_to root_path, class: "custom-text text-xl font-semibold" do %>
+        <%= link_to root_path, class: "custom-text hover:opacity-80 text-xl font-semibold" do %>
           Sakura Thanks
         <% end %>
       </div>
       <div class="flex-none gap-4">
         <%= link_to "一覧ページ", posts_path, class: "custom-text hover:opacity-80" %>
-        <%= link_to "マイページ", mypage_path, class: "custom-text hover:opacity-80" %>
         <% if logged_in? %>
+          <%= link_to "マイページ", mypage_path, class: "custom-text hover:opacity-80" %>
           <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete }, class: "custom-text hover:opacity-80" %>
         <% else %>
           <%= link_to "ログイン", login_path, class: "custom-text hover:opacity-80" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   resources :users, only: %i[new create]
-  resources :posts, only: %i[index new create]
+  resources :posts, only: %i[index new create show]
 
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"


### PR DESCRIPTION
closes #73

# 投稿詳細機能の実装
- [x] 投稿一覧画面に表示中の掲示板のタイトルもしくは画像をクリックすると掲示板詳細画面へ遷移。
## 掲示板詳細画面には以下が表示。
- [x] 掲示板のタイトル
- [x] 掲示板の本文
- [x] 掲示板を投稿したユーザーネーム
