### PR TITLE
update:投稿詳細ページの画像の高さ制限なくした

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,9 +6,9 @@
       <%# 画像部分 %>
       <div class="bg-white rounded-lg shadow-lg overflow-hidden">
         <% if @post.image.attached? %>
-          <%= image_tag @post.image, class: "w-full h-64 object-cover" %>
+          <%= image_tag @post.image, class: "w-full" %>
         <% else %>
-          <%= image_tag "Cropped_Image copy.png", class: "w-full h-64 object-cover" %>
+          <%= image_tag "Cropped_Image copy.png", class: "w-full" %>
         <% end %>
       </div>
 


### PR DESCRIPTION
本番環境で画面大きさが制限されていたので修正
h-64 object-coverをなくし下記の通りに変更
```
<div class="bg-white rounded-lg shadow-lg overflow-hidden">
  <% if @post.image.attached? %>
    <%= image_tag @post.image, class: "w-full" %>
  <% else %>
    <%= image_tag "Cropped_Image copy.png", class: "w-full" %>
  <% end %>
</div>
```