### PR TITLE
フラッシュメッセージ作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,6 +14,7 @@ def create
   if @post.save
     redirect_to mypage_path, success: "投稿を作成しました"
   else
+    flash.now[:danger] = "投稿の作成に失敗しました"
     render :new, status: :unprocessable_entity
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,13 +2,15 @@ module ApplicationHelper
   def type_to_alert_class(type)
     case type.to_sym
     when :success
-      'bg-[#36D399]'  # 緑色
-    when :danger
-      'bg-[#F87272]'  # 赤色
+      "alert-success"
+    when :danger, :error
+      "alert-error"
     when :warning
-      'bg-[#FBBD23]'  # 黄色
+      "alert-warning"
+    when :info
+      "alert-info"
     else
-      'bg-[#3ABFF8]'  # 青色
+      "alert-info"
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,14 @@
 module ApplicationHelper
+  def type_to_alert_class(type)
+    case type.to_sym
+    when :success
+      'bg-[#36D399]'  # 緑色
+    when :danger
+      'bg-[#F87272]'  # 赤色
+    when :warning
+      'bg-[#FBBD23]'  # 黄色
+    else
+      'bg-[#3ABFF8]'  # 青色
+    end
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,8 +9,8 @@ class Post < ApplicationRecord
   # 属性名を日本語化
   def self.human_attribute_name(attr, options = {})
     {
-      title: 'タイトル',
-      content: '内容'
+      title: "タイトル",
+      content: "内容"
     }[attr.to_sym] || super
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,14 @@ class Post < ApplicationRecord
   # has_many :favorites, dependent: :destroy
   has_one_attached :image  # Active Storageの関連付けを追加
 
+  # 属性名を日本語化
+  def self.human_attribute_name(attr, options = {})
+    {
+      title: 'タイトル',
+      content: '内容'
+    }[attr.to_sym] || super
+  end
+
   validates :title, presence: { message: "を入力してください" }
   validates :content, presence: { message: "を入力してください" }
   # 画像の検証

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
 
 <body class="min-h-screen bg-base-100 flex flex-col">
     <%= render 'shared/header' %>
+    <%= render 'shared/flash_message' %>
     <main class="flex-grow">
       <%= yield %>
     </main>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,6 +1,17 @@
 <div class="container mx-auto px-4">
- <div class="max-w-2xl mx-auto">
-   <%= form_with(model: post, local: true, class: "space-y-6") do |f| %>
+  <div class="max-w-2xl mx-auto">
+    <%= form_with(model: post, local: true, class: "space-y-6") do |f| %>
+      <%# エラーメッセージ表示部分 %>
+      <% if post.errors.any? %>
+        <div class="space-y-2 mb-4">
+          <% post.errors.full_messages.each do |message| %>
+            <div class="alert w-full text-sm text-white bg-[#F87272]">
+              <%= message %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+      <%# 既存のフォーム部分 %>
      <div class="flex justify-center mb-6">
       <div id="image-preview" class="w-1/2 aspect-square flex items-center justify-center overflow-hidden" style="background-color: #D9D9D9 !important; min-height: 200px;">
         <% if post.image.attached? %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,14 +3,14 @@
     <%= form_with(model: post, local: true, class: "space-y-6") do |f| %>
       <%# エラーメッセージ表示部分 %>
       <% if post.errors.any? %>
-        <div class="space-y-2 mb-4">
-          <% post.errors.full_messages.each do |message| %>
-            <div class="alert w-full text-sm text-white bg-[#F87272]">
-              <%= message %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+  <div class="space-y-2 mb-4">
+    <% post.errors.full_messages.each do |message| %>
+      <div class="alert alert-error w-full text-sm shadow-lg">
+        <%= message %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
       <%# 既存のフォーム部分 %>
      <div class="flex justify-center mb-6">
       <div id="image-preview" class="w-1/2 aspect-square flex items-center justify-center overflow-hidden" style="background-color: #D9D9D9 !important; min-height: 200px;">

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,7 @@
+<div class="fixed top-4 left-1/2 transform -translate-x-1/2">
+  <% flash.each do |type, message| %>
+    <div class="alert text-white w-80 text-sm <%= type_to_alert_class(type) %>">
+      <%= message %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,6 +1,6 @@
 <div class="fixed top-4 left-1/2 transform -translate-x-1/2">
   <% flash.each do |type, message| %>
-    <div class="alert text-white w-80 text-sm <%= type_to_alert_class(type) %>">
+    <div class="alert w-80 text-sm <%= type_to_alert_class(type) %> shadow-lg">
       <%= message %>
     </div>
   <% end %>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,11 @@ module.exports = {
         "primary-content": "#FFFFFF",
         "neutral": "#89AAD3",
         "neutral-content": "#FFFFFF",
+        // 以下を追加
+        "success": "#36D399",  // 成功時の色
+        "error": "#F87272",    // エラー時の色
+        "warning": "#FBBD23",  // 警告時の色
+        "info": "#3ABFF8"      // 情報時の色
       }
     }]
   }


### PR DESCRIPTION
closes #82
ユーザーとポストそれぞれに対してフラッシュメッセージ表示
- [x] 新規ユーザー登録時（成功・失敗）にフラッシュメッセージを表示
- [x] ログイン時（成功・失敗）にフラッシュメッセージを表示
- [x] ログアウト時（成功）にフラッシュメッセージを表示
- [x] ポスト新規投稿時（成功・失敗）にフラッシュメッセージを表示
- [x] ポスト更新時（成功・失敗）にフラッシュメッセージを表示
- [x] ポスト削除時（成功・失敗）にフラッシュメッセージを表示