### PR TITLE
fix:CDエラー解消のため

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update -qq && \
     curl \
     default-mysql-client \
     libpq-dev \
-    libmysqlclient-dev \
+    libmariadb-dev-compat \
+    libmariadb-dev \
     git \
     nodejs \
     npm \


### PR DESCRIPTION
CDエラーを解消のため
/Users/user/sakura_thanks/Dockerfileの
libmysqlclient-devをlibmariadb-dev-compatとlibmariadb-devに置き換え