### PR TITLE
ブックマーク挙動修正（非同期）

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -4,14 +4,18 @@ class BookmarksController < ApplicationController
     current_user.bookmark(@post)
 
     respond_to do |format|
-      format.html { 
+      format.html {
         flash[:success] = "投稿をブックマークしました"
-        redirect_back(fallback_location: posts_path) 
+        redirect_back(fallback_location: posts_path)
       }
-      format.turbo_stream { 
+      format.turbo_stream {
         flash.now[:success] = "投稿をブックマークしました"
-        render turbo_stream: turbo_stream.replace("bookmark_btn_#{@post.id}", 
-          partial: 'application/bookmark_button', locals: { post: @post }) 
+        render turbo_stream: [
+          turbo_stream.replace("bookmark_btn_#{@post.id}",
+            partial: "application/bookmark_button", locals: { post: @post }),
+          turbo_stream.replace("flash_messages",
+            partial: "shared/flash_message")
+        ]
       }
     end
   end
@@ -22,14 +26,18 @@ class BookmarksController < ApplicationController
     current_user.unbookmark(@post)
 
     respond_to do |format|
-      format.html { 
+      format.html {
         flash[:success] = "ブックマークを削除しました"
-        redirect_back(fallback_location: posts_path, status: :see_other) 
+        redirect_back(fallback_location: posts_path, status: :see_other)
       }
-      format.turbo_stream { 
+      format.turbo_stream {
         flash.now[:success] = "ブックマークを削除しました"
-        render turbo_stream: turbo_stream.replace("bookmark_btn_#{@post.id}", 
-          partial: 'application/bookmark_button', locals: { post: @post }) 
+        render turbo_stream: [
+          turbo_stream.replace("bookmark_btn_#{@post.id}",
+            partial: "application/bookmark_button", locals: { post: @post }),
+          turbo_stream.replace("flash_messages",
+            partial: "shared/flash_message")
+        ]
       }
     end
   end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -3,20 +3,34 @@ class BookmarksController < ApplicationController
     @post = Post.find(params[:post_id])
     current_user.bookmark(@post)
 
-    # 通知メッセージだけを追加
-    flash[:success] = "投稿をブックマークしました"
-
-    # リダイレクト
-    redirect_back(fallback_location: posts_path)
+    respond_to do |format|
+      format.html { 
+        flash[:success] = "投稿をブックマークしました"
+        redirect_back(fallback_location: posts_path) 
+      }
+      format.turbo_stream { 
+        flash.now[:success] = "投稿をブックマークしました"
+        render turbo_stream: turbo_stream.replace("bookmark_btn_#{@post.id}", 
+          partial: 'application/bookmark_button', locals: { post: @post }) 
+      }
+    end
   end
 
   def destroy
     @bookmark = current_user.bookmarks.find(params[:id])
-    post = @bookmark.post
-    current_user.unbookmark(post)
+    @post = @bookmark.post
+    current_user.unbookmark(@post)
 
-    flash[:success] = "ブックマークを削除しました"
-    # status: :see_other を外し、redirect_backにオプションとして渡す
-    redirect_back(fallback_location: posts_path, status: :see_other)
+    respond_to do |format|
+      format.html { 
+        flash[:success] = "ブックマークを削除しました"
+        redirect_back(fallback_location: posts_path, status: :see_other) 
+      }
+      format.turbo_stream { 
+        flash.now[:success] = "ブックマークを削除しました"
+        render turbo_stream: turbo_stream.replace("bookmark_btn_#{@post.id}", 
+          partial: 'application/bookmark_button', locals: { post: @post }) 
+      }
+    end
   end
 end

--- a/app/views/application/_bookmark_button.html.erb
+++ b/app/views/application/_bookmark_button.html.erb
@@ -1,15 +1,16 @@
-<% if current_user && current_user.bookmark?(post) %>
-  <%= link_to bookmark_path(current_user.bookmarks.find_by(post_id: post.id)), 
-      data: { turbo_method: :delete }, 
-      style: "color: #DD7594;", 
-      class: "hover:opacity-80" do %>
-    <i class="fas fa-heart"></i>
+<div id="bookmark_btn_<%= post.id %>">
+  <% if current_user&.bookmark?(post) %>
+    <%= button_to bookmark_path(current_user.bookmarks.find_by(post_id: post.id)), 
+                 method: :delete,
+                 class: "bookmark-btn",
+                 data: { turbo_method: :delete, turbo_stream: true } do %>
+                  <i class="fas fa-heart"></i>
+    <% end %>
+  <% else %>
+    <%= button_to bookmarks_path(post_id: post.id), 
+                 class: "bookmark-btn",
+                 data: { turbo_stream: true } do %>
+                  <i class="far fa-heart"></i>
+    <% end %>
   <% end %>
-<% else %>
-  <%= link_to bookmarks_path(post_id: post.id), 
-      data: { turbo_method: :post }, 
-      class: "text-gray-400 hover:opacity-80", 
-      style: "hover:color: #DD7594;" do %>
-    <i class="far fa-heart"></i>
-  <% end %>
-<% end %>
+</div>

--- a/app/views/application/_bookmark_button.html.erb
+++ b/app/views/application/_bookmark_button.html.erb
@@ -4,13 +4,13 @@
                  method: :delete,
                  class: "bookmark-btn",
                  data: { turbo_method: :delete, turbo_stream: true } do %>
-                  <i class="fas fa-heart"></i>
+                  <i class="fas fa-heart" style="color: #DD7594;"></i>
     <% end %>
   <% else %>
     <%= button_to bookmarks_path(post_id: post.id), 
                  class: "bookmark-btn",
                  data: { turbo_stream: true } do %>
-                  <i class="far fa-heart"></i>
+                  <i class="far fa-heart text-gray-400 hover:opacity-80"></i>
     <% end %>
   <% end %>
 </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,4 +1,4 @@
-<div class="fixed top-4 left-1/2 transform -translate-x-1/2">
+<div id="flash_messages" class="fixed top-4 left-1/2 transform -translate-x-1/2">
   <% flash.each do |type, message| %>
     <% if message.is_a?(String) && type != "status" %> <!-- 文字列かつstatusでない場合のみ表示 -->
       <div class="alert w-80 text-sm <%= type_to_alert_class(type) %> shadow-lg">


### PR DESCRIPTION
closes #159
## ブックマークを非同期に改善
詳細ページ・お気に入りページでブックマークをすると一覧ページにリダイレクト
→ページ遷移せずにブックマークができる挙動に修正